### PR TITLE
Fix: branch used for monotools/semver-yeasy action

### DIFF
--- a/.github/workflows/gitversion.yml
+++ b/.github/workflows/gitversion.yml
@@ -44,7 +44,7 @@ jobs:
         (git checkout develop && git checkout - ) || true; 
 
     - name: Checkout to branch
-      uses: mrsauravsahu/monotools/apps/semver-yeasy@improv/all-json-outputs
+      uses: mrsauravsahu/monotools/apps/semver-yeasy
       id: checkout
       with:
         repo-type: 'MONOREPO'
@@ -52,7 +52,7 @@ jobs:
 
     - name: Calculate changed services
       id: calculate_changed_services
-      uses: mrsauravsahu/monotools/apps/semver-yeasy@improv/all-json-outputs
+      uses: mrsauravsahu/monotools/apps/semver-yeasy
       with:
         repo-type: 'MONOREPO'
         mode: 'changed'
@@ -74,7 +74,7 @@ jobs:
         JQ_EXEC_PATH: /usr/bin/jq
         SEMVERYEASY_CHANGED_SERVICES: ${{ fromJSON(steps.generate_other_targets.outputs.SERVICES) }}
         GITVERSION_CONFIG_MONOREPO: ${{ env.GITVERSION_CONFIG_MONOREPO }}
-      uses: mrsauravsahu/monotools/apps/semver-yeasy@improv/all-json-outputs
+      uses: mrsauravsahu/monotools/apps/semver-yeasy
       with: 
         repo-type: MONOREPO
         mode: calculate-version
@@ -97,7 +97,7 @@ jobs:
 
     - name: Update PR description
       if: ${{ github.event_name == 'pull_request' }}
-      uses: mrsauravsahu/monotools/apps/semver-yeasy@improv/all-json-outputs
+      uses: mrsauravsahu/monotools/apps/semver-yeasy
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEMVERY_YEASY_PR_BODY: ${{ steps.calculate_service_versions.outputs.PR_BODY }}
@@ -109,7 +109,7 @@ jobs:
 
     - name: Tag build
       if: ${{ github.event_name == 'push' && (startsWith(steps.calculate_changed_services.outputs.diff_dest, 'release') || startsWith(steps.calculate_changed_services.outputs.diff_dest, 'hotfix')) && steps.calculate_changed_services.outputs.changed_services != '' }}
-      uses: mrsauravsahu/monotools/apps/semver-yeasy@improv/all-json-outputs
+      uses: mrsauravsahu/monotools/apps/semver-yeasy
       env:
         SEMVERYEASY_CHANGED_SERVICES: ${{ fromJSON(steps.generate_other_targets.outputs.SERVICES) }}
       with:


### PR DESCRIPTION
- remove use of temporary branch in composite action